### PR TITLE
회원 정보 수정 기능 관련 리팩토링

### DIFF
--- a/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/home/HomeService.java
+++ b/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/home/HomeService.java
@@ -23,7 +23,7 @@ public class HomeService {
 
         List<Home> examples = homeRepository.findAll();
         return examples.stream()
-                .map(HomeResponse::of)
+                .map(HomeResponse::from)
                 .collect(Collectors.toList());
     }
 

--- a/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/home/response/HomeResponse.java
+++ b/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/home/response/HomeResponse.java
@@ -11,7 +11,7 @@ public record HomeResponse(String image, String sentence) {
         this.sentence = sentence;
     }
 
-    public static HomeResponse of(Home home) {
+    public static HomeResponse from(Home home) {
         return HomeResponse.builder()
                 .image(home.getImage())
                 .sentence(home.getSentence())

--- a/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/styling/StylingService.java
+++ b/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/styling/StylingService.java
@@ -22,7 +22,7 @@ public class StylingService {
 
         List<Styling> examples = stylingRepository.findAll();
         return examples.stream()
-                .map(StylingExampleResponse::of)
+                .map(StylingExampleResponse::from)
                 .collect(Collectors.toList());
     }
 

--- a/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/styling/response/StylingExampleResponse.java
+++ b/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/styling/response/StylingExampleResponse.java
@@ -9,7 +9,7 @@ public record StylingExampleResponse(String image, String prompt) {
         this.image = image;
         this.prompt = prompt;
     }
-    public static StylingExampleResponse of(Styling styling) {
+    public static StylingExampleResponse from(Styling styling) {
         return StylingExampleResponse.builder()
                 .image(styling.getImage())
                 .prompt(styling.getPrompt())

--- a/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/user/response/UserUpdateResponse.java
+++ b/spring-server/aistyling/src/main/java/com/clothz/aistyling/api/service/user/response/UserUpdateResponse.java
@@ -12,7 +12,7 @@ public record UserUpdateResponse(String email, String nickname, String password)
         this.password = password;
     }
 
-    public static UserUpdateResponse of(User user){
+    public static UserUpdateResponse from(User user){
         return UserUpdateResponse.builder()
                 .email(user.getEmail())
                 .nickname(user.getNickname())

--- a/spring-server/aistyling/src/main/java/com/clothz/aistyling/domain/user/User.java
+++ b/spring-server/aistyling/src/main/java/com/clothz/aistyling/domain/user/User.java
@@ -1,7 +1,5 @@
 package com.clothz.aistyling.domain.user;
 
-import com.clothz.aistyling.api.controller.user.request.UserUpdateRequest;
-import com.clothz.aistyling.api.service.user.response.UserUpdateResponse;
 import com.clothz.aistyling.domain.BaseEntity;
 import com.clothz.aistyling.domain.user.constant.UserRole;
 import jakarta.persistence.*;
@@ -41,7 +39,7 @@ public class User extends BaseEntity {
     }
 
     public void updatePassword(String password){
-        this.password=password;
+        this.password = password;
     }
 
     public void updateNickname(String nickname){

--- a/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/controller/home/HomeControllerTest.java
+++ b/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/controller/home/HomeControllerTest.java
@@ -6,7 +6,6 @@ import com.clothz.aistyling.domain.home.Home;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -39,8 +38,8 @@ public class HomeControllerTest {
         //given
         given(homeService.getImageAndSentence()).willReturn(
                 List.of(
-                        HomeResponse.of(new Home("image1", "introduce1")),
-                        HomeResponse.of(new Home("image2", "introduce2"))
+                        HomeResponse.from(new Home("image1", "introduce1")),
+                        HomeResponse.from(new Home("image2", "introduce2"))
                 ));
 
         //when

--- a/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/controller/styling/StylingControllerTest.java
+++ b/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/controller/styling/StylingControllerTest.java
@@ -40,8 +40,8 @@ class StylingControllerTest {
         //given
         given(stylingService.getImageAndPrompt()).willReturn(
                 List.of(
-                        StylingExampleResponse.of(new Styling("images1", "prompt example 1")),
-                        StylingExampleResponse.of(new Styling("images2", "prompt example 2"))
+                        StylingExampleResponse.from(new Styling("images1", "prompt example 1")),
+                        StylingExampleResponse.from(new Styling("images2", "prompt example 2"))
                 ));
 
         //when

--- a/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/service/home/HomeServiceTest.java
+++ b/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/service/home/HomeServiceTest.java
@@ -28,8 +28,8 @@ public class HomeServiceTest {
         Assertions.assertThat(imageAndSentence)
                 .hasSize(2)
                 .containsExactlyInAnyOrder(
-                        HomeResponse.of(new Home("image1", "introduce1")),
-                        HomeResponse.of(new Home("image2", "introduce2"))
+                        HomeResponse.from(new Home("image1", "introduce1")),
+                        HomeResponse.from(new Home("image2", "introduce2"))
                 );
     }
 }

--- a/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/service/styling/StylingServiceTest.java
+++ b/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/service/styling/StylingServiceTest.java
@@ -8,10 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -30,8 +27,8 @@ class StylingServiceTest {
         assertThat(imageAndPrompt)
                 .hasSize(2)
                 .containsExactlyInAnyOrder(
-                        StylingExampleResponse.of(new Styling("images1", "prompt example 1")),
-                        StylingExampleResponse.of(new Styling("images2", "prompt example 2"))
+                        StylingExampleResponse.from(new Styling("images1", "prompt example 1")),
+                        StylingExampleResponse.from(new Styling("images2", "prompt example 2"))
                 );
     }
 }

--- a/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/service/user/UserServiceTest.java
+++ b/spring-server/aistyling/src/test/java/com/clothz/aistyling/api/service/user/UserServiceTest.java
@@ -4,7 +4,6 @@ import com.clothz.aistyling.api.controller.user.request.UserCreateRequest;
 import com.clothz.aistyling.api.controller.user.request.UserUpdateRequest;
 import com.clothz.aistyling.api.service.user.response.UserInfoResponse;
 import com.clothz.aistyling.api.service.user.response.UserSingUpResponse;
-import com.clothz.aistyling.api.service.user.response.UserUpdateResponse;
 import com.clothz.aistyling.domain.user.User;
 import com.clothz.aistyling.domain.user.UserRepository;
 import com.clothz.aistyling.domain.user.constant.UserRole;
@@ -51,7 +50,7 @@ class UserServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        User user = User.builder()
+        final User user = User.builder()
                 .nickname(NICKNAME)
                 .email(EMAIL)
                 .password(delegatingPasswordEncoder.encode(PASSWORD))
@@ -104,7 +103,7 @@ class UserServiceTest {
         //when
         //then
         Assertions.assertThatThrownBy(() -> {
-                    userService.sameCheckEmail(request.email());
+                    userService.signUp(request);
                 }).isInstanceOf(DuplicateKeyException.class)
                 .hasMessageContaining("Email already exists");
     }
@@ -148,17 +147,20 @@ class UserServiceTest {
         //given
         final User user = userRepository.findByEmail(EMAIL).orElseThrow();
 
-        String email = "user12@gmail.com";
-        String updateNickName = "updateUser";
-        String updatePassWord = "updatePassword";
-        UserUpdateRequest request = UserUpdateRequest.builder().email(email).password(updatePassWord).nickname(updateNickName).build();
+        final String email = "user12@gmail.com";
+        final String updateNickName = "updateUser";
+        final String updatePassWord = "updatePassword";
+        final UserUpdateRequest request = UserUpdateRequest.builder()
+                .email(EMAIL)
+                .password(updatePassWord)
+                .nickname(updateNickName)
+                .build();
 
         //when
         userService.updateUser(request);
         final User updateUser = userRepository.findByEmail(EMAIL).orElseThrow();
 
         //then
-        assertThat(updateUser.getPassword()).isEqualTo(updatePassWord);
         assertThat(updateUser.getNickname()).isEqualTo(updateNickName);
     }
 }


### PR DESCRIPTION
## 주요 사항
- 리팩토링
  - sameCheckEmail과 checkEmailExist의 메서드 이름이 유사하지만 다른 기능이라서 가독성을 높이기 위해 메서드를 제거했습니다
  - 비밀번호 변경 시 암호화 하도록 했습니다
  - 정적 팩토리 메서드 이름을 적절하게 변경했습니다
 
## 관련 이슈
#7 